### PR TITLE
Add script for fetching latest Instagram comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # tiendasamc-gpt
 Repositorio para automatización de respuestas en Instagram con IA
+
+## Obtener comentarios de Instagram
+
+El script `get_instagram_comments.py` permite consultar los comentarios más recientes de una cuenta de Instagram mediante el Graph API de Meta.
+
+Uso básico:
+
+```bash
+python get_instagram_comments.py PAGE_ID ACCESS_TOKEN
+```
+
+Donde:
+- `PAGE_ID` es el identificador de la página de Facebook asociada a la cuenta de Instagram.
+- `ACCESS_TOKEN` es un token de acceso con permisos para leer la información de la página y los comentarios de Instagram.
+
+Opcionalmente se puede especificar `--limit` para indicar cuántas publicaciones recientes revisar (por defecto 25).
+
+El script muestra los comentarios ordenados por fecha, indicando usuario, texto y el `media_id` de la publicación a la que pertenecen.

--- a/get_instagram_comments.py
+++ b/get_instagram_comments.py
@@ -1,0 +1,73 @@
+import argparse
+import requests
+
+
+def get_instagram_business_account(page_id: str, access_token: str) -> str | None:
+    """Return the instagram business account id for a given page."""
+    url = f"https://graph.facebook.com/v17.0/{page_id}"
+    params = {"fields": "instagram_business_account", "access_token": access_token}
+    resp = requests.get(url, params=params)
+    resp.raise_for_status()
+    data = resp.json()
+    ig_account = data.get("instagram_business_account")
+    if ig_account:
+        return ig_account.get("id")
+    return None
+
+
+def fetch_latest_comments(ig_user_id: str, access_token: str, limit: int = 25) -> list[dict]:
+    """Fetch comments from recent media and return them sorted by timestamp."""
+    url = f"https://graph.facebook.com/v17.0/{ig_user_id}/media"
+    params = {"fields": "id,caption,timestamp", "access_token": access_token, "limit": limit}
+    resp = requests.get(url, params=params)
+    resp.raise_for_status()
+    media_items = resp.json().get("data", [])
+
+    comments: list[dict] = []
+    for media in media_items:
+        media_id = media["id"]
+        comment_url = f"https://graph.facebook.com/v17.0/{media_id}/comments"
+        comment_params = {
+            "fields": "id,username,text,timestamp",
+            "access_token": access_token,
+        }
+        com_resp = requests.get(comment_url, params=comment_params)
+        if not com_resp.ok:
+            continue
+        for comment in com_resp.json().get("data", []):
+            comment["media_id"] = media_id
+            comments.append(comment)
+
+    comments.sort(key=lambda c: c.get("timestamp", ""), reverse=True)
+    return comments
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch latest Instagram comments via Graph API.")
+    parser.add_argument("page_id", help="Facebook Page ID connected to the Instagram business account")
+    parser.add_argument("access_token", help="Graph API access token")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=25,
+        help="Number of media items to retrieve comments from (default: 25)",
+    )
+    args = parser.parse_args()
+
+    ig_user_id = get_instagram_business_account(args.page_id, args.access_token)
+    if not ig_user_id:
+        raise SystemExit(
+            "Could not retrieve instagram business account. Ensure the page ID and token are valid."
+        )
+
+    comments = fetch_latest_comments(ig_user_id, args.access_token, args.limit)
+    for com in comments:
+        ts = com.get("timestamp")
+        user = com.get("username")
+        text = com.get("text")
+        media_id = com.get("media_id")
+        print(f"[{ts}] @{user}: {text} (media {media_id})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python script `get_instagram_comments.py` to retrieve recent Instagram comments with the Meta Graph API
- update README with usage instructions for the script

## Testing
- `python3 get_instagram_comments.py -h`
- `python3 -m py_compile get_instagram_comments.py`

------
https://chatgpt.com/codex/tasks/task_e_68409809e014832d88240b767e62996a